### PR TITLE
Restore Close/Read/Write methods for streams

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -76,6 +76,10 @@ func (v *Stream) Finish() error {
 	return nil
 }
 
+func (v *Stream) Close() error {
+	return v.Finish()
+}
+
 func (v *Stream) Free() error {
 	result := C.virStreamFree(v.ptr)
 	if result == -1 {

--- a/stream.go
+++ b/stream.go
@@ -101,6 +101,10 @@ func (v *Stream) Recv(p []byte) (int, error) {
 	return int(n), nil
 }
 
+func (v *Stream) Read(p []byte) (int, error) {
+	return v.Recv(p)
+}
+
 func (v *Stream) Send(p []byte) (int, error) {
 	n := C.virStreamSend(v.ptr, (*C.char)(unsafe.Pointer(&p[0])), C.size_t(len(p)))
 	if n < 0 {
@@ -111,6 +115,10 @@ func (v *Stream) Send(p []byte) (int, error) {
 	}
 
 	return int(n), nil
+}
+
+func (v *Stream) Write(p []byte) (int, error) {
+	return v.Send(p)
 }
 
 type StreamSinkFunc func(*Stream, []byte) (int, error)


### PR DESCRIPTION
They make streams implement Reader/Writer/Closer interfaces which makes them usable by a lot of functions.