### PR TITLE
Pass NULL to virDomainOpenConsole if dvename is an empty string

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -4074,8 +4074,11 @@ func (d *Domain) OpenChannel(name string, stream *Stream, flags DomainChannelFla
 }
 
 func (d *Domain) OpenConsole(devname string, stream *Stream, flags DomainConsoleFlags) error {
-	cdevname := C.CString(devname)
-	defer C.free(unsafe.Pointer(cdevname))
+	var cdevname *C.char = nil
+	if devname != "" {
+		cdevname = C.CString(devname)
+		defer C.free(unsafe.Pointer(cdevname))
+	}
 
 	ret := C.virDomainOpenConsole(d.ptr, cdevname, stream.ptr, C.uint(flags))
 	if ret == -1 {


### PR DESCRIPTION
In order to let libvirt select the first available serial console, NULL
needs to be passed in. If an empty string is passsed in, libvirt tries
to find a console with that name instead.

Fixes #11.