### PR TITLE
domain: check address slice

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -1832,10 +1832,11 @@ func (d *Domain) ListAllInterfaceAddresses(src uint) ([]DomainInterface, error) 
 
 		for k := 0; k < numAddr; k++ {
 			ifaces[i].Addrs[k] = DomainIPAddress{}
-			ifaces[i].Addrs[k].Type = int(addrSlice[k]._type)
-			ifaces[i].Addrs[k].Addr = C.GoString(addrSlice[k].addr)
-			ifaces[i].Addrs[k].Prefix = uint(addrSlice[k].prefix)
-
+			if addrSlice[k] != nil {
+				ifaces[i].Addrs[k].Type = int(addrSlice[k]._type)
+				ifaces[i].Addrs[k].Addr = C.GoString(addrSlice[k].addr)
+				ifaces[i].Addrs[k].Prefix = uint(addrSlice[k].prefix)
+			}
 		}
 		C.virDomainInterfaceFreeCompat(ifaceSlice[i])
 	}


### PR DESCRIPTION
This fixes a NPE which happens if an element of addrSlice is nil. In
this case, the address will be an empty DomainIPAddress struct.

The NPE was noticed while trying to retrieve the interface addresses via

```go
domain.ListAllInterfaceAddresses(uint(libvirt.DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT))
```

Signed-off-by: Thomas Hipp <thipp@suse.de>