### PR TITLE
virDomainListGetStats accepts a nil terminated array

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -2427,7 +2427,7 @@ func (c *Connect) GetAllDomainStats(doms []*Domain, statsTypes DomainStatsTypes,
 	var ret C.int
 	var cstats *C.virDomainStatsRecordPtr
 	if len(doms) > 0 {
-		cdoms := make([]C.virDomainPtr, len(doms))
+		cdoms := make([]C.virDomainPtr, len(doms)+1)
 		for i := 0; i < len(doms); i++ {
 			cdoms[i] = doms[i].ptr
 		}


### PR DESCRIPTION
virDomainListGetStats expectes a `nil` terminated array, hence we need to allocate the `cdoms` with `len(doms) + 1` to have a nil element at the end, otherwise this will
occasionally SIGFAULT