### PR TITLE
fix MemoryStats return struct

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -1710,7 +1710,7 @@ func (d *Domain) MemoryStats(nrStats uint32, flags uint32) ([]DomainMemoryStat, 
 		return []DomainMemoryStat{}, GetLastError()
 	}
 
-	out := make([]DomainMemoryStat, result)
+	out := make([]DomainMemoryStat, 0, result)
 	for i := 0; i < int(result); i++ {
 		out = append(out, DomainMemoryStat{
 			Tag: int32(ptr[i].tag),


### PR DESCRIPTION
if we do not initialize out struct if zero size, on every append empty element will double, so if we request 10 memory parameters in nrStats the output out length will be 20.